### PR TITLE
Tweak to work with Fluentd v0.14 compatibile layer

### DIFF
--- a/lib/fluent/plugin/out_redeliver.rb
+++ b/lib/fluent/plugin/out_redeliver.rb
@@ -1,6 +1,11 @@
 class Fluent::RedeliverOutput < Fluent::Output
   Fluent::Plugin.register_output('redeliver', self)
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   include Fluent::SetTagKeyMixin
   config_set_default :include_tag_key, false
 
@@ -41,7 +46,7 @@ class Fluent::RedeliverOutput < Fluent::Output
       es.each do |time, record|
         if (record)
           filter_record(tag, time, record)
-          Fluent::Engine.emit(newtag, time, record)
+          router.emit(newtag, time, record)
         end
       end
     end


### PR DESCRIPTION
Because Fluentd v0.14 treats Engine.emit as a bug.
We should use router#emit instead.